### PR TITLE
Add unit tests and make streamlit optional

### DIFF
--- a/dog_calories.py
+++ b/dog_calories.py
@@ -1,4 +1,7 @@
-import streamlit as st
+try:
+    import streamlit as st
+except ModuleNotFoundError:  # Allow importing without Streamlit installed
+    st = None
 from collections import defaultdict
 
 # Set Lists and Dictionary
@@ -19,24 +22,33 @@ def calculate_calories(dog_weight, dog_age, dog_size):
     dog_rer = calculate_rer(dog_weight,dog_size)
     return round(dog_rer * calc_dict[dog_age], 2)
 
-# Set title     
-st.title("PetCalulator:dog:")
+def main():
+    """Run the Streamlit UI if Streamlit is available."""
+    if st is None:
+        raise RuntimeError("Streamlit is required to run the UI")
 
-# Display app description
-st.caption("An estimated calculation of the daily caloric needs for your dog")
+    # Set title
+    st.title("PetCalulator:dog:")
 
-# Display disclaimer
-st.caption("Please Note: This estimate does not replace the professional health advice of a veterinarian.")
+    # Display app description
+    st.caption("An estimated calculation of the daily caloric needs for your dog")
 
-# Display input fields
-dog_age = st.selectbox("Select your dog's age/condition", options=age_list,index=2)
-dog_size = st.select_slider("Select your dog's size", options=size_list,value=size_list[1])
-dog_weight = st.number_input("Enter your dog's current weight in kg", min_value=0.0, step=0.5, value=28.0)
+    # Display disclaimer
+    st.caption("Please Note: This estimate does not replace the professional health advice of a veterinarian.")
 
-# Calculate calories and display output
-if st.button("Calculate"):
-    calories = calculate_calories(dog_weight, dog_age, dog_size)
-    if dog_age == age_list[0] or dog_age == age_list[1]:
-        st.write(f"Your dog's GER (Growth Energy Requirements) is {calories} calories per day.")
-    else:
-        st.write(f"Your dog's DER (Daily Energy Requirements) is {calories} calories per day.")
+    # Display input fields
+    dog_age = st.selectbox("Select your dog's age/condition", options=age_list,index=2)
+    dog_size = st.select_slider("Select your dog's size", options=size_list,value=size_list[1])
+    dog_weight = st.number_input("Enter your dog's current weight in kg", min_value=0.0, step=0.5, value=28.0)
+
+    # Calculate calories and display output
+    if st.button("Calculate"):
+        calories = calculate_calories(dog_weight, dog_age, dog_size)
+        if dog_age == age_list[0] or dog_age == age_list[1]:
+            st.write(f"Your dog's GER (Growth Energy Requirements) is {calories} calories per day.")
+        else:
+            st.write(f"Your dog's DER (Daily Energy Requirements) is {calories} calories per day.")
+
+
+if __name__ == "__main__" and st is not None:
+    main()

--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -1,0 +1,21 @@
+import unittest
+
+from dog_calories import calculate_rer, calculate_calories, size_list, age_list
+
+class TestCalculations(unittest.TestCase):
+    def test_calculate_rer_inside_range(self):
+        # 10kg medium size should use 30*weight + 70
+        self.assertEqual(calculate_rer(10, size_list[1]), 370.0)
+
+    def test_calculate_rer_outside_range(self):
+        # 1kg small size should use 70*(weight**0.75)
+        self.assertEqual(calculate_rer(1, size_list[0]), 70.0)
+
+    def test_calculate_calories_neutered_adult(self):
+        # 10kg medium dog with age 'Normal Neutered Adult' uses multiplier 1.6
+        rer = calculate_rer(10, size_list[1])
+        expected = round(rer * 1.6, 2)
+        self.assertEqual(calculate_calories(10, age_list[2], size_list[1]), expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- modify `dog_calories.py` so its Streamlit UI only runs when executed directly
- add unit tests for RER and calorie calculations

## Testing
- `python -m unittest -v`


------
https://chatgpt.com/codex/tasks/task_e_68425e3b406883289ee8e504e06c78ae